### PR TITLE
Fix: Configure npm test to correctly run application tests

### DIFF
--- a/node1/package.json
+++ b/node1/package.json
@@ -4,12 +4,15 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node node1/app.js & node node1/test.js && kill $!"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "node-fetch": "^2.6.7"
   }
 }


### PR DESCRIPTION
The `npm run test` command was previously misconfigured and did not execute any actual tests, always returning an error.

This commit addresses the issue by:
1. Modifying `node1/package.json` to update the `scripts.test` command. The new command now:
    - Starts the application server (`node1/app.js`) in the background.
    - Executes the test suite (`node1/test.js`).
    - Stops the application server after tests are complete.
2. Adding `node-fetch` (version ^2.6.7) to `devDependencies` in `node1/package.json`, as it is required by `node1/test.js`.

This ensures that `npm run test` will now properly execute the defined tests against a running instance of the application.